### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/book/splitter.js
+++ b/book/splitter.js
@@ -1,6 +1,6 @@
 /// <reference path="../typings/tsd.d.ts" />
 
-require(['gitbook', 'jQuery', 'lodash'], function (gitbook, $, _) {
+require(['gitbook', 'jQuery'], function (gitbook, $) {
 
 	gitbook.events.bind('start', function () {
 	});
@@ -37,21 +37,21 @@ require(['gitbook', 'jQuery', 'lodash'], function (gitbook, $, _) {
 			splitState.summaryOffset,
 			splitState.bookBodyOffset
 		);
-		
-		_.defer(function() {
+
+		setTimeout(function() {
 			var isGreaterThanEqualGitbookV2_5 = !Boolean($('.toggle-summary').length);
 
-			var $toggleSummary = isGreaterThanEqualGitbookV2_5 
+			var $toggleSummary = isGreaterThanEqualGitbookV2_5
 				? $('.fa.fa-align-justify').parent() : $('.toggle-summary');
 
 			$toggleSummary.on('click', function () {
-	
+
 				var summaryOffset  = null;
 				var bookBodyOffset = null;
-				
-				var isOpen = isGreaterThanEqualGitbookV2_5 
+
+				var isOpen = isGreaterThanEqualGitbookV2_5
 					? !gitbook.sidebar.isOpen() : $book.hasClass('with-summary');
-		
+
 				if (isOpen) {
 					summaryOffset  = -($summary.outerWidth());
 					bookBodyOffset = 0;
@@ -59,11 +59,11 @@ require(['gitbook', 'jQuery', 'lodash'], function (gitbook, $, _) {
 					summaryOffset  = 0;
 					bookBodyOffset = $summary.outerWidth();
 				}
-	
+
 				setSplitState($summary.outerWidth(), summaryOffset, bookBodyOffset);
 				saveSplitState($summary.outerWidth(), summaryOffset, bookBodyOffset);
 			});
-		});
+		}, 1);
 
 		$divider.on('mousedown', function (event) {
 			event.stopPropagation();
@@ -114,7 +114,7 @@ require(['gitbook', 'jQuery', 'lodash'], function (gitbook, $, _) {
 			$bookBody.offset({ left: bookBodyOffset });
 			// improved broken layout in windows chrome.
 			//   "$(x).offset" automatically add to "position:relative".
-			//   but it cause layout broken.. 
+			//   but it cause layout broken..
 			$summary.css({ position: 'absolute' });
 			$bookBody.css({ position: 'absolute' });
 		}


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, GitBook will not expose the lodash module to improve performance.

The proposed PR has been tested with the new version.
It only clears the dependency to lodash using a native `setTimeout` instead of `_.defer()`, which is [basically the implementation of this function](https://github.com/lodash/lodash/blob/4.11.1/lodash.js#L9514).
Let me know if you have any remarks regarding what is done, and don't forget to publish a new version if you merge it :)

Kind regards,
Johan
